### PR TITLE
Incorrect container height for auto width layout.

### DIFF
--- a/jquery.nanogallery.js
+++ b/jquery.nanogallery.js
@@ -2571,7 +2571,7 @@ function nanoGALLERY() {
         });
         
         
-        $g_containerThumbnails.width(areaW).height(curPosY+gO.thumbnailHeight);
+        $g_containerThumbnails.width(areaW).height(curPosY);
       }
       else {
         


### PR DESCRIPTION
I'm sorry if I don't see something obvious, but it seems to me that the addition of a thumbnail height is not needed here. It generates incorrect container height (too large). I had to fix it to make it look right.
Here's the example of incorrect container height:
http://jsfiddle.net/XMC54/
