### PR TITLE
Hide pagination container, if not used.

### DIFF
--- a/jquery.nanogallery.js
+++ b/jquery.nanogallery.js
@@ -3721,10 +3721,15 @@ this.thumbImgHeight = 0;           // thumbnail image height
     if( $gE.conPagin == undefined ) return;
     
     $gE.conPagin.children().remove();
-    $gE.conPagin.hide ();
 
-    if( g_tn.settings.height[g_curNavLevel][g_curWidth] == 'auto' || g_tn.settings.width[g_curNavLevel][g_curWidth] == 'auto' ) { return; }
+    if( g_tn.settings.height[g_curNavLevel][g_curWidth] == 'auto' || g_tn.settings.width[g_curNavLevel][g_curWidth] == 'auto' ) {
+        // Hide pagination container, if not used.
+        $gE.conPagin.hide ();
+        return;
+    }
     
+    // Must show the container for width calculation to work.
+    $gE.conPagin.show ();
     $gE.conPagin.data('galleryIdx',albumIdx);
     $gE.conPagin.data('currentPageNumber',pageNumber);
     var n2=0,
@@ -3756,7 +3761,11 @@ this.thumbImgHeight = 0;           // thumbnail image height
     }
     
     // only one page -> do not display anything
-    if( n2==1 ) { return; }
+    if( n2==1 ) {
+        // Hide pagination container, if not used.
+        $gE.conPagin.hide ();
+        return;
+    }
     
     for(var i=firstPage; i < n2; i++ ) {
       var c='';
@@ -3783,7 +3792,6 @@ this.thumbImgHeight = 0;           // thumbnail image height
       });
     }
 
-    $gE.conPagin.show ();
     $gE.conPagin.width(w);
 
   }


### PR DESCRIPTION
Hey!
If my memory serves, before version 5.0.1 pagination container wasn't shown when there was no pagination. But now it is displayed anyway, creating additional padding at the bottom when pagination is disabled. How about hiding the pagination container when it is empty?

jsfiddle:
before: http://jsfiddle.net/mooncat/3myrmarf/embedded/result/
after: http://jsfiddle.net/mooncat/xnkk3445/embedded/result/
