### PR TITLE
Added GetCurrentItem to API

### DIFF
--- a/jquery.nanogallery.js
+++ b/jquery.nanogallery.js
@@ -178,6 +178,9 @@ nanoGALLERY v5.7.0 release notes.
         case 'getSelectedItems':
           return $(this).data('nanoGallery').nG.GetSelectedItems();
           break;
+        case 'getCurrentItem':
+          return $(this).data('nanoGallery').nG.GetCurrentItem();
+          break;
         case 'selectItems':
           $(this).data('nanoGallery').nG.SetSelectedItems(option);
           break;
@@ -380,7 +383,15 @@ nanoGALLERY v5.7.0 release notes.
     this.GetSelectedItems = function(){
       return G.selectedItems;
     };
-
+    
+     /**
+     * Returns current index of image in viewer
+     * @returns {int}
+     */
+    this.GetCurrentItem = function(){
+      return G.viewerCurrentItemIdx;
+    };
+    
     /**
      * Returns the value of an option
      * @param {string} option


### PR DESCRIPTION
Returns the index of the current item being viewed. Can be used in combination with GetItem to return all information about current view in slideshow.